### PR TITLE
Include license in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include updater/VERSION
+include LICENSE


### PR DESCRIPTION
This will include the license file in the sdist. Context: I'm trying to get this package onto conda-forge and they require license files to be bundled into the sdist tar.